### PR TITLE
Fix CSS background image mode in Firefox

### DIFF
--- a/src/jquery.adaptive-backgrounds.js
+++ b/src/jquery.adaptive-backgrounds.js
@@ -67,6 +67,7 @@
 
         var getCSSBackground = function(){
           return $this.css('background-image')
+                      .replace('url("','').replace('")','')
                       .replace('url(','').replace(')','');
         };
 


### PR DESCRIPTION
In Firefox, running

    $elem.css("background-image")

returns something like

    url("http://host/path/to/img")

unlike Webkit browsers, who return

    url(http://host/path/to/img)

Trying to get rid of quotes first should fix the problem.